### PR TITLE
Add missing functions for satisfying dynamodbiface.dynamodbapi

### DIFF
--- a/dax/api.go
+++ b/dax/api.go
@@ -463,6 +463,19 @@ func (d *Dax) DescribeTableRequest(*dynamodb.DescribeTableInput) (r *request.Req
 	return
 }
 
+func (d *Dax) DescribeTableReplicaAutoScaling(*dynamodb.DescribeTableReplicaAutoScalingInput) (*dynamodb.DescribeTableReplicaAutoScalingOutput, error) {
+	return nil, d.unImpl()
+}
+
+func (d *Dax) DescribeTableReplicaAutoScalingWithContext(aws.Context, *dynamodb.DescribeTableReplicaAutoScalingInput, ...request.Option) (*dynamodb.DescribeTableReplicaAutoScalingOutput, error) {
+	return nil, d.unImpl()
+}
+
+func (d *Dax) DescribeTableReplicaAutoScalingRequest(*dynamodb.DescribeTableReplicaAutoScalingInput) (r *request.Request, o *dynamodb.DescribeTableReplicaAutoScalingOutput) {
+	d.unImpl()
+	return
+}
+
 func (d *Dax) DescribeTimeToLive(*dynamodb.DescribeTimeToLiveInput) (*dynamodb.DescribeTimeToLiveOutput, error) {
 	return nil, d.unImpl()
 }
@@ -636,6 +649,19 @@ func (d *Dax) UpdateTableWithContext(aws.Context, *dynamodb.UpdateTableInput, ..
 }
 
 func (d *Dax) UpdateTableRequest(*dynamodb.UpdateTableInput) (r *request.Request, o *dynamodb.UpdateTableOutput) {
+	d.unImpl()
+	return
+}
+
+func (d *Dax) UpdateTableReplicaAutoScaling(*dynamodb.UpdateTableReplicaAutoScalingInput) (*dynamodb.UpdateTableReplicaAutoScalingOutput, error) {
+	return nil, d.unImpl()
+}
+
+func (d *Dax) UpdateTableReplicaAutoScalingWithContext(aws.Context, *dynamodb.UpdateTableReplicaAutoScalingInput, ...request.Option) (*dynamodb.UpdateTableReplicaAutoScalingOutput, error) {
+	return nil, d.unImpl()
+}
+
+func (d *Dax) UpdateTableReplicaAutoScalingRequest(*dynamodb.UpdateTableReplicaAutoScalingInput) (r *request.Request, o *dynamodb.UpdateTableReplicaAutoScalingOutput) {
 	d.unImpl()
 	return
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
After the release of version 1.25.40, there are functions newly added into the dynamodbiface interface. These newly functions has broken Dax casting in here and unit tests became invalid;

`var _ dynamodbiface.DynamoDBAPI = (*Dax)(nil)`

For that reason, I added new functions as unimplemented with their correct signatures.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
