### PR TITLE
Optionally specify a custom dialer when creating a client

### DIFF
--- a/dax/internal/client/cluster_test.go
+++ b/dax/internal/client/cluster_test.go
@@ -16,18 +16,22 @@
 package client
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net"
 	"reflect"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -616,6 +620,43 @@ func newTestClusterWithConfig(config Config) (*cluster, *testClientBuilder) {
 
 func setExpectation(cluster *cluster, ep []serviceEndpoint) {
 	cluster.clientBuilder.(*testClientBuilder).ep = ep
+}
+
+func TestCluster_customDialer(t *testing.T) {
+	ours, theirs := net.Pipe()
+	wg := &sync.WaitGroup{}
+	var result []byte
+	go func() {
+		wg.Add(1)
+		defer wg.Done()
+
+		for {
+			buf := make([]byte, 4096)
+			n, _ := ours.Read(buf)
+			result = buf[:n]
+			ours.Close()
+			return
+		}
+	}()
+
+	var dialFn contextDialer = func(ctx context.Context, address string, network string) (net.Conn, error) {
+		return theirs, nil
+	}
+	cfg := Config{
+		MaxPendingConnectionsPerHost: 1,
+		ClusterUpdateInterval:        1 * time.Second,
+		Credentials:                  credentials.NewStaticCredentials("id", "secret", "tok"),
+		DialFn:                       dialFn,
+		Region:                       "us-west-2",
+		HostPorts:                    []string{"localhost:9121"},
+	}
+	cc, err := New(cfg)
+	require.NoError(t, err)
+	cc.GetItemWithOptions(&dynamodb.GetItemInput{TableName: aws.String("MyTable")}, &dynamodb.GetItemOutput{}, RequestOptions{})
+
+	wg.Wait()
+
+	assert.Equal(t, magic, string(result[1:8]), "expected the ClusterClient to write to the connection provided by the custom dialer")
 }
 
 type testClientBuilder struct {

--- a/dax/internal/client/single.go
+++ b/dax/internal/client/single.go
@@ -78,14 +78,17 @@ type SingleDaxClient struct {
 }
 
 func NewSingleClient(endpoint, region string, credentials *credentials.Credentials) (*SingleDaxClient, error) {
-	return newSingleClientWithOptions(endpoint, region, credentials, -1)
+	return newSingleClientWithOptions(endpoint, region, credentials, -1, nil)
 
 }
 
-func newSingleClientWithOptions(endpoint, region string, credentials *credentials.Credentials, maxPendingConnections int) (*SingleDaxClient, error) {
+func newSingleClientWithOptions(endpoint, region string, credentials *credentials.Credentials, maxPendingConnections int, dialer contextDialer) (*SingleDaxClient, error) {
 	po := defaultTubePoolOptions
 	if maxPendingConnections > 0 {
 		po.maxConcurrentConnAttempts = maxPendingConnections
+	}
+	if dialer != nil {
+		po.dialFn = dialer
 	}
 	client := &SingleDaxClient{
 		region:             region,

--- a/dax/internal/client/single_test.go
+++ b/dax/internal/client/single_test.go
@@ -16,6 +16,8 @@ import (
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestExecuteErrorHandling(t *testing.T) {
@@ -78,11 +80,11 @@ func TestExecuteErrorHandling(t *testing.T) {
 	}
 
 	for i, c := range cases {
-		cli, err := newSingleClientWithOptions(":9121", "us-west-2", credentials.NewStaticCredentials("id", "secret", "tok"), 1)
+		cli, err := newSingleClientWithOptions(":9121", "us-west-2", credentials.NewStaticCredentials("id", "secret", "tok"), 1, nil)
 		if err != nil {
 			t.Fatalf("unexpected error %v", err)
 		}
-		cli.pool.connectFn = func(a, n string) (net.Conn, error) {
+		cli.pool.connectFn = func(ctx context.Context, a, n string) (net.Conn, error) {
 			return c.conn, nil
 		}
 		cli.pool.closeTubeImmediately = true
@@ -99,13 +101,13 @@ func TestExecuteErrorHandling(t *testing.T) {
 }
 
 func TestRetryPropogatesContextError(t *testing.T) {
-	client, clientErr := newSingleClientWithOptions(":9121", "us-west-2", credentials.NewStaticCredentials("id", "secret", "tok"), 1)
+	client, clientErr := newSingleClientWithOptions(":9121", "us-west-2", credentials.NewStaticCredentials("id", "secret", "tok"), 1, nil)
 	defer client.Close()
 	if clientErr != nil {
 		t.Fatalf("unexpected error %v", clientErr)
 	}
 
-	client.pool.connectFn = func(a, n string) (net.Conn, error) {
+	client.pool.connectFn = func(ctx context.Context, a, n string) (net.Conn, error) {
 		return &mockConn{rd: []byte{cbor.Array + 0}}, nil
 	}
 	client.pool.closeTubeImmediately = true
@@ -135,13 +137,13 @@ func TestRetryPropogatesContextError(t *testing.T) {
 }
 
 func TestRetryPropogatesOtherErrors(t *testing.T) {
-	client, clientErr := newSingleClientWithOptions(":9121", "us-west-2", credentials.NewStaticCredentials("id", "secret", "tok"), 1)
+	client, clientErr := newSingleClientWithOptions(":9121", "us-west-2", credentials.NewStaticCredentials("id", "secret", "tok"), 1, nil)
 	defer client.Close()
 	if clientErr != nil {
 		t.Fatalf("unexpected error %v", clientErr)
 	}
 
-	client.pool.connectFn = func(a, n string) (net.Conn, error) {
+	client.pool.connectFn = func(ctx context.Context, a, n string) (net.Conn, error) {
 		return &mockConn{rd: []byte{cbor.Array + 0}}, nil
 	}
 	client.pool.closeTubeImmediately = true
@@ -172,13 +174,13 @@ func TestRetryPropogatesOtherErrors(t *testing.T) {
 }
 
 func TestRetryPropogatesOtherErrorsWithDelay(t *testing.T) {
-	client, clientErr := newSingleClientWithOptions(":9121", "us-west-2", credentials.NewStaticCredentials("id", "secret", "tok"), 1)
+	client, clientErr := newSingleClientWithOptions(":9121", "us-west-2", credentials.NewStaticCredentials("id", "secret", "tok"), 1, nil)
 	defer client.Close()
 	if clientErr != nil {
 		t.Fatalf("unexpected error %v", clientErr)
 	}
 
-	client.pool.connectFn = func(a, n string) (net.Conn, error) {
+	client.pool.connectFn = func(ctx context.Context, a, n string) (net.Conn, error) {
 		return &mockConn{rd: []byte{cbor.Array + 0}}, nil
 	}
 	client.pool.closeTubeImmediately = true
@@ -210,13 +212,13 @@ func TestRetryPropogatesOtherErrorsWithDelay(t *testing.T) {
 }
 
 func TestRetrySleepCycleCount(t *testing.T) {
-	client, clientErr := newSingleClientWithOptions(":9121", "us-west-2", credentials.NewStaticCredentials("id", "secret", "tok"), 1)
+	client, clientErr := newSingleClientWithOptions(":9121", "us-west-2", credentials.NewStaticCredentials("id", "secret", "tok"), 1, nil)
 	defer client.Close()
 	if clientErr != nil {
 		t.Fatalf("unexpected error %v", clientErr)
 	}
 
-	client.pool.connectFn = func(a, n string) (net.Conn, error) {
+	client.pool.connectFn = func(ctx context.Context, a, n string) (net.Conn, error) {
 		return &mockConn{rd: []byte{cbor.Array + 0}}, nil
 	}
 	client.pool.closeTubeImmediately = true
@@ -246,13 +248,13 @@ func TestRetrySleepCycleCount(t *testing.T) {
 }
 
 func TestRetryLastError(t *testing.T) {
-	client, clientErr := newSingleClientWithOptions(":9121", "us-west-2", credentials.NewStaticCredentials("id", "secret", "tok"), 1)
+	client, clientErr := newSingleClientWithOptions(":9121", "us-west-2", credentials.NewStaticCredentials("id", "secret", "tok"), 1, nil)
 	defer client.Close()
 	if clientErr != nil {
 		t.Fatalf("unexpected error %v", clientErr)
 	}
 
-	client.pool.connectFn = func(a, n string) (net.Conn, error) {
+	client.pool.connectFn = func(ctx context.Context, a, n string) (net.Conn, error) {
 		return &mockConn{rd: []byte{cbor.Array + 0}}, nil
 	}
 	client.pool.closeTubeImmediately = true
@@ -285,6 +287,19 @@ func TestRetryLastError(t *testing.T) {
 	if awsError.Code() != "UnknownError" || awsError.OrigErr().Error() != "LastError" {
 		t.Fatalf("aws error doesn't match expected. %v", awsError)
 	}
+}
+
+func TestSingleClient_customDialer(t *testing.T) {
+	conn := &mockConn{}
+	var dialFn contextDialer = func(ctx context.Context, address string, network string) (net.Conn, error) {
+		return conn, nil
+	}
+	client, err := newSingleClientWithOptions(":9121", "us-west-2", credentials.NewStaticCredentials("id", "secret", "tok"), 1, dialFn)
+	require.NoError(t, err)
+	defer client.Close()
+
+	c, _ := client.pool.connectFn(context.TODO(), "address", "network")
+	assert.Equal(t, conn, c)
 }
 
 type mockConn struct {


### PR DESCRIPTION
*Issue #, if available:*
#13 

*Description of changes:*
This change allows consumers to control how they create connections to
a DAX cluster, e.g. using a SOCKS proxy dialer to access a cluster
when running integration tests outside of the cluster's VPC.

I've included some rudimentary unit tests to verify that the cluster
is using the dialer when specified and ran some ad-hoc tests from my
laptop to confirm that I can connect to a DAX endpoint via a SOCKS
proxy from a program running outside the cluster's VPC.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
