### PR TITLE
feat: update to new Dynamo transaction limit

### DIFF
--- a/dax/internal/client/request.go
+++ b/dax/internal/client/request.go
@@ -142,7 +142,7 @@ const (
 	returnValueOnConditionCheckFailureAllOld
 )
 
-const maxWriteBatchSize = 25
+const maxWriteBatchSize = 100
 
 func encodeEndpointsInput(writer *cbor.Writer) error {
 	if err := encodeServiceAndMethod(endpoints_455855874_1_Id, writer); err != nil {
@@ -423,12 +423,12 @@ func encodeBatchWriteItemInput(ctx aws.Context, input *dynamodb.BatchWriteItemIn
 		l := len(wrs)
 		if l == 0 {
 			return awserr.New(request.InvalidParameterErrCode, fmt.Sprintf("1 validation error detected: Value '{%s=%d}' at 'requestItems' failed to satisfy constraint:"+
-				" Map value must satisfy constraint: [Member must have length less than or equal to 25, Member must have length greater than or equal to 1", table, l), nil)
+				" Map value must satisfy constraint: [Member must have length less than or equal to 100, Member must have length greater than or equal to 1", table, l), nil)
 		}
 		totalRequests = totalRequests + l
 		if totalRequests > maxWriteBatchSize {
 			return awserr.New(request.InvalidParameterErrCode, fmt.Sprintf("1 validation error detected: Value '{%s=%d}' at 'requestItems' failed to satisfy constraint:"+
-				" Map value must satisfy constraint: [Member must have length less than or equal to 25, Member must have length greater than or equal to 1", table, totalRequests), nil)
+				" Map value must satisfy constraint: [Member must have length less than or equal to 100, Member must have length greater than or equal to 1", table, totalRequests), nil)
 		}
 
 		if err = writer.WriteString(table); err != nil {

--- a/dax/internal/client/request.go
+++ b/dax/internal/client/request.go
@@ -428,7 +428,7 @@ func encodeBatchWriteItemInput(ctx aws.Context, input *dynamodb.BatchWriteItemIn
 		totalRequests = totalRequests + l
 		if totalRequests > maxWriteBatchSize {
 			return awserr.New(request.InvalidParameterErrCode, fmt.Sprintf("1 validation error detected: Value '{%s=%d}' at 'requestItems' failed to satisfy constraint:"+
-				" Map value must satisfy constraint: [Member must have length less than or equal to 100, Member must have length greater than or equal to 1", table, totalRequests), nil)
+				" Map value must satisfy constraint: [Member must have length less than or equal to %d, Member must have length greater than or equal to 1", table, l, maxWriteBatchSize), nil)
 		}
 
 		if err = writer.WriteString(table); err != nil {

--- a/dax/internal/client/request.go
+++ b/dax/internal/client/request.go
@@ -423,7 +423,7 @@ func encodeBatchWriteItemInput(ctx aws.Context, input *dynamodb.BatchWriteItemIn
 		l := len(wrs)
 		if l == 0 {
 			return awserr.New(request.InvalidParameterErrCode, fmt.Sprintf("1 validation error detected: Value '{%s=%d}' at 'requestItems' failed to satisfy constraint:"+
-				" Map value must satisfy constraint: [Member must have length less than or equal to 100, Member must have length greater than or equal to 1", table, l), nil)
+				" Map value must satisfy constraint: [Member must have length less than or equal to %d, Member must have length greater than or equal to 1", table, l, maxWriteBatchSize), nil)
 		}
 		totalRequests = totalRequests + l
 		if totalRequests > maxWriteBatchSize {


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/aws/aws-dax-go/issues/40

*Description of changes:*
I updated the maxWriteBatchSize to 100, to align with new DynamoDB limits https://aws.amazon.com/about-aws/whats-new/2022/09/amazon-dynamodb-supports-100-actions-per-transaction/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
