### PR TITLE
fix: updating the dax interface to match the DynamoDB interface for t…

### DIFF
--- a/dax/api.go
+++ b/dax/api.go
@@ -901,6 +901,17 @@ func (d *Dax) UpdateGlobalTableSettingsRequest(*dynamodb.UpdateGlobalTableSettin
 	return newRequestForUnimplementedOperation(), &dynamodb.UpdateGlobalTableSettingsOutput{}
 }
 
+func (d *Dax) UpdateKinesisStreamingDestination(*dynamodb.UpdateKinesisStreamingDestinationInput) (*dynamodb.UpdateKinesisStreamingDestinationOutput, error) {
+	return nil, d.unImpl()
+}
+func (d *Dax) UpdateKinesisStreamingDestinationWithContext(aws.Context, *dynamodb.UpdateKinesisStreamingDestinationInput, ...request.Option) (*dynamodb.UpdateKinesisStreamingDestinationOutput, error) {
+	return nil, d.unImpl()
+}
+
+func (d *Dax) UpdateKinesisStreamingDestinationRequest(*dynamodb.UpdateKinesisStreamingDestinationInput) (*request.Request, *dynamodb.UpdateKinesisStreamingDestinationOutput) {
+	return nil, nil
+}
+
 func (d *Dax) UpdateTable(*dynamodb.UpdateTableInput) (*dynamodb.UpdateTableOutput, error) {
 	return nil, d.unImpl()
 }


### PR DESCRIPTION
[Issue 52](https://github.com/aws/aws-dax-go/issues/52)

This PR creates placeholders values for the DynamoDB interface released in the [v.15.0](https://github.com/aws/aws-sdk-go/pull/5147/files) version of aws-sdk-go.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
